### PR TITLE
Show pin types even if there are no pins added

### DIFF
--- a/lib/renderMap.js
+++ b/lib/renderMap.js
@@ -115,23 +115,18 @@ function getPoints(mapData) {
 function getTypes(mapData) {
 	var deferred = Q.defer();
 
-	if (mapData.points.length > 0) {
-		loadTypes(mapData.id).then(
-			function (points) {
-				mapData.types = points;
-				deferred.resolve(mapData);
-			},
-			function (error) {
-				deferred.reject({
-					code: 500,
-					message: error
-				});
-			}
-		);
-	} else {
-		mapData.types = [];
-		deferred.resolve(mapData);
-	}
+	loadTypes(mapData.id).then(
+		function (points) {
+			mapData.types = points;
+			deferred.resolve(mapData);
+		},
+		function (error) {
+			deferred.reject({
+				code: 500,
+				message: error
+			});
+		}
+	);
 
 	return deferred.promise;
 }


### PR DESCRIPTION
Based on email exchange with Rich:

> > When user adds POI category and no POIs for it - should we display it in filter box?
> 
> Yes we should. It allows people to know what kind of POIs there are and what they can add. They might see no POIs for castles and be influenced to add one.
