### PR TITLE
Fix for dev-interactivemaps

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -46,7 +46,7 @@ try {
 	throw 'Problem with config: ' + e;
 }
 
-configuration.swift = swiftConfiguration.wgFSSwiftConfig[environment][env.WIKIA_PROD_DATACENTER];
+configuration.swift = swiftConfiguration.wgFSSwiftConfig[environment][env.WIKIA_PROD_DATACENTER.toLowerCase()];
 
 configuration.setRoot = function (dir) {
 	dir = dir || '';


### PR DESCRIPTION
On dev-interactivemaps devbox, env.WIKIA_PROD_DATACENTER is uppercase.
In file Swift.yml there is corresponding object property with lowercase name.
This simple change fixes whole thing.
