### PR TITLE
Enable CORS in Interactive Maps API server

### DIFF
--- a/apiServer.js
+++ b/apiServer.js
@@ -33,6 +33,13 @@ var express = require('express'),
 //build routes for Version 1
 routeBuilder(router, crudModules, apiPath);
 
+// enable CORS for all requests (possiblty apiAbsolutePath could be used insteaf of *)
+app.all('*', function(req, res, next) {
+	res.header("Access-Control-Allow-Origin", "*");
+	res.header("Access-Control-Allow-Headers", "X-Requested-With");
+	next();
+});
+
 app.use(guard);
 app.use(logger.middleware);
 app.use(rawBody);


### PR DESCRIPTION
It is required (unless JSONP is supported) to be able to use this API within AJAX.
