### PR TITLE
Make place for scrollbar

### DIFF
--- a/assets/styles/leaflet-wikia.css
+++ b/assets/styles/leaflet-wikia.css
@@ -183,7 +183,7 @@
 .point-type span {
 	display: inline-block;
 	vertical-align: middle;
-	width: 155px;
+	width: 135px;
 	word-wrap: break-word;
 }
 


### PR DESCRIPTION
@RafLeszczynski @rogatty @aquilax As discussed on friday evening with @nandy-andy, we could make span inside the point type li item a bit more narrow so we can get rid of the issue with the windows scrollbar messing around with the elements positioning.
