### PR TITLE
Send messages to correct queue that belongs to interactive_maps worker

### DIFF
--- a/lib/taskQueue.js
+++ b/lib/taskQueue.js
@@ -9,7 +9,7 @@ var url = require('url'),
 	logger = require('./logger'),
 	utils = require('./utils'),
 	queueName = 'interactive_maps',
-	taskIdPrefix = 'mw-',
+	taskIdPrefix = 'im-',
 	tasks = {
 		poiUpdate: 'celery_workers.interactive_maps.parse'
 	};


### PR DESCRIPTION
per suggestion from @nmonterroso we need to change the name of the queue to interactive_maps.

@aquilax or @RafLeszczynski could you review this PR?
