### PR TITLE
MWEB-941 Changed the color of popup's title

### DIFF
--- a/assets/styles/leaflet-wikia.css
+++ b/assets/styles/leaflet-wikia.css
@@ -105,11 +105,15 @@ html,
 }
 
 .leaflet-popup h3 {
-	color: #0078A8;
+	color: #000;
 	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.leaflet-popup h3 a {
+	color: #0078A8;
 }
 
 .leaflet-popup a {


### PR DESCRIPTION
We'd like the users to be able to differentiate clickable versus non-clickable pin titles in the pin popup. Therefore, the "title" text's color was changed to black.
