### PR TITLE
Logger should take two args

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -141,7 +141,7 @@ if (cluster.isMaster) {
 }
 
 process.on('uncaughtException', function (err) {
-	logger.critical('uncaughtException:', err.message, {
+	logger.critical('uncaughtException: ' + err.message, {
 		stack: err.stack
 	});
 	process.exit(1);


### PR DESCRIPTION
@nandy-andy @rogatty @RafLeszczynski Logger methods should take two arguments. After Exception caught by 'uncaughtException' module we don't know anything about the details of the exception cause logger throws another one. This needs to be fixed and this PR fixes it.
