### PR TITLE
MWEB-700 Use LIKE in SQL query to find map templates

### DIFF
--- a/api/v1/tile_set.utils.js
+++ b/api/v1/tile_set.utils.js
@@ -56,9 +56,9 @@ function processTileSetCollection(collection, req, process) {
  * @param {String} search - search term
  */
 function addSearchToQuery(query, search) {
+	// MWEB-700 after discussion with OPS it's safe here to use LIKE until tile_set table gets 50k-200k rows
 	query
-		.join('tile_set_search', 'tile_set.id', '=', 'tile_set_search.id')
-		.whereRaw('MATCH (tile_set_search.name) AGAINST (?)', [search])
+		.where('tile_set.name', 'like', '%' + search + '%')
 		.orderBy('created_on', 'desc');
 }
 


### PR DESCRIPTION
Because of performance reasons we used a separate table in MySQL with `InnoDB` engine to use full text search feature. Unfortunately from the user-side perspective MySQL fulltext search didn't work out because of its limitations: users weren't able to find "California" template if they had typed "Cal" into search input.

We discussed it with OPS team and using LIKE is safe here for now. We'll be monitoring rows in `tile_set` table and once it gets close to 50k rows we'll have to change the solution to a different one.

Changes below simply remove fulltext search and add "LIKE search".
