### PR TITLE
Mweb 1073

### DIFF
--- a/lib/renderMap.js
+++ b/lib/renderMap.js
@@ -318,7 +318,6 @@ function renderMap(req, res, next, apiPathEntryPoint, apiConfigUrl) {
 		dbCon.getConnection(dbCon.connType.all, function (conn) {
 			loadRenderData(req, conn, mapId)
 				.then(function (mapData) {
-					conn.release();
 					return setupMap(req, mapData);
 				})
 				.then(function (mapData) {


### PR DESCRIPTION
@nandy-andy @rogatty This is getting us back to using callback instead of promise here as a catch/fail block is not working properly and the exception is caught by our middleware for serving 404s as JSON (hence the JSON message in render). 

I'll put the other fixes for https://wikia-inc.atlassian.net/browse/MWEB-1073 here (if there will be any) as well.
