### PR TITLE
Fall back to default bg when get-pixels fails

### DIFF
--- a/lib/imageBackground.js
+++ b/lib/imageBackground.js
@@ -66,7 +66,9 @@ function getBgColorForImage(jobData) {
 	getPixels(imgPath, function (err, pixels) {
 		if (err) {
 			logger.error('Error while getting image pixels ' + JSON.stringify(err));
-			deferred.reject(err);
+			//For transparent png get-pixels fails, so fall back to default color
+			jobData.bgColor = defaultBgColor;
+			deferred.resolve(jobData);
 			return;
 		}
 


### PR DESCRIPTION
@nandy-andy @rogatty 

NPM's get-pixels module fails for a specific type of PNG interlacing for transparent images.

This works around it by setting the default background color when get-pixels fails.

I decided to open pull request to release branch as we have nothing new in dev and we can backport the whole release branch to it after merging this bugfix.
