### PR TITLE
DAT-2529, Revert thumbnail cachebuster changes required by 404 vignette issues

### DIFF
--- a/lib/renderMap.js
+++ b/lib/renderMap.js
@@ -97,20 +97,13 @@ function handleDefaultCategory(mapData) {
  * @returns {String}
  */
 function getPathTemplate(tileSetId) {
-	/*
-	 FIXME this is a temporary fix for MWEB-1100
-	 We have 404s cached for a week and need to add cache buster until they are expired
-	 This should be removed on 2015-02-16 (first Monday after expiration time)
-	 */
-	var cacheBuster = '?cb=20150206';
-
 	return utils.imageUrl(
 		config.dfsHost,
 		utils.getBucketName(
 			config.bucketPrefix + config.tileSetPrefix,
 			tileSetId
 		),
-		'{z}/{x}/{y}.png' + cacheBuster
+		'{z}/{x}/{y}.png'
 	);
 }
 


### PR DESCRIPTION
This reverts commit 1f787a9b642bb671792dd6ca731f949d1ce7754b, reversing
changes made to 401e14a888b7e854ba29212d37b2eaac98552463.