### PR TITLE
MAIN-4002 Fix marker filename

### DIFF
--- a/lib/jobProcessors.js
+++ b/lib/jobProcessors.js
@@ -147,7 +147,7 @@ function updateTileSet(job) {
  */
 function clearMarker(data) {
 	var deferred = Q.defer(),
-		fileName = data.dir + url.parse(data.fileUrl).pathname.split('/').pop();
+		fileName = data.dir + utils.getFileNameFromPathName(data.fileUrl);
 
 	fs.unlink(fileName, function (err) {
 		if (err) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-4002

We had errors like:
```
[DEBUG] Saved file: 20150205033602%21phpRjLJW1.jpg
[INFO] Original image saved to intmap_markers_100
[ERROR] {"errno":34,"code":"ENOENT","path":"/tmp/interactive-maps/latest"}
```

This should fix them.

/cc @RafLeszczynski 