### PR TITLE
Use addTrailingSlash in the responseUrl method

### DIFF
--- a/api/v1/map.crud.js
+++ b/api/v1/map.crud.js
@@ -97,7 +97,7 @@ function createMap(req, res, next) {
 
 			utils.extendObject(response, {
 				id: mapId,
-				url: utils.responseUrl(req, utils.addTrailingSlash(req.route.path), mapId)
+				url: utils.responseUrl(req, req.route.path, mapId)
 			});
 
 			utils.sendHttpResponse(res, 201, response);

--- a/api/v1/map.utils.js
+++ b/api/v1/map.utils.js
@@ -35,7 +35,7 @@ function buildMapCollectionResult(collection, req) {
 		);
 		value.url = utils.responseUrl(
 			req,
-			utils.addTrailingSlash(req.route.path),
+			req.route.path,
 			value.id
 		);
 

--- a/api/v1/poi.crud.js
+++ b/api/v1/poi.crud.js
@@ -68,7 +68,7 @@ function createPoi(req, res, next) {
 
 			utils.extendObject(response, {
 				id: poiId,
-				url: utils.responseUrl(req, utils.addTrailingSlash(req.route.path), poiId)
+				url: utils.responseUrl(req, req.route.path, poiId)
 			});
 
 			return utils.changeMapUpdatedOn(dbConnection, dbCon, mapId);

--- a/api/v1/poi_category.utils.js
+++ b/api/v1/poi_category.utils.js
@@ -116,7 +116,7 @@ function setupCreatePoiCategoryResponse(id, req) {
 	return {
 		message: poiCategoryConfig.responseMessages.created,
 		id: id,
-		url: utils.responseUrl(req, utils.addTrailingSlash(req.route.path), id)
+		url: utils.responseUrl(req, req.route.path, id)
 	};
 }
 

--- a/api/v1/tile_set.utils.js
+++ b/api/v1/tile_set.utils.js
@@ -93,7 +93,7 @@ function setupCreateTileSetResponse(dbRes, req) {
 	return {
 		message: message,
 		id: id,
-		url: utils.responseUrl(req, utils.addTrailingSlash(req.route.path), id)
+		url: utils.responseUrl(req, req.route.path, id)
 	};
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,7 +170,7 @@ module.exports = {
 	 */
 	responseUrl: function (req, path, id) {
 		path = path.replace(':id', '');
-		return req.protocol + '://' + req.headers.host + path + id;
+		return req.protocol + '://' + req.headers.host + this.addTrailingSlash(path) + id;
 	},
 
 	/**


### PR DESCRIPTION
Trailing slash was forgotten at least in one place:
https://github.com/Wikia/interactive-maps/blob/b9d3781113a1a202c2283cd463d2f8d777e216f2/api/v1/tile_set.utils.js#L26

This caused url fields in http://maps.wikia-services.com/api/v1/tile_set to be like:
`url: "http://maps.wikia-services.com/api/v1/tile_set2"`
instead of:
`url: "http://maps.wikia-services.com/api/v1/tile_set/2"`

This fixes the problem and prevents it from occuring again.

/cc @nandy-andy @bkoval @RafLeszczynski 