### PR TITLE
CONCF-611: temporary work-around for purging issues

### DIFF
--- a/lib/renderMap.js
+++ b/lib/renderMap.js
@@ -311,7 +311,7 @@ function renderError(apiConfigUrl, res, error) {
 function renderMap(req, res, next, apiPathEntryPoint, apiConfigUrl) {
 	var mapId = parseInt(req.params.id, 10) || 0;
 
-	res.setCacheValidity(caching.cacheShort);
+	// res.setCacheValidity(caching.cacheShort);
 	res.setSurrogateKey(utils.surrogateKeyPrefix + mapId);
 
 	if (mapId !== 0) {


### PR DESCRIPTION
Cache time is short (5 minutes) and the api call itself is very fast so for now we can improve the usability of maps by just skipping the cache while we investigate the purger issues.  

@rafalkalinski @macbre 