### PR TITLE
config: remove support for dfsProxy setting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,8 +12,7 @@ var yaml = require('js-yaml'),
 	environment,
 	charset = 'utf8',
 	// service name known by Fastly
-	serviceName = 'interactive-maps',
-	dfsProxyKey = 'dfsProxy';
+	serviceName = 'interactive-maps';
 
 if (!env.WIKIA_CONFIG_ROOT) {
 	throw new Error('WIKIA_CONFIG_ROOT seems to be not set');
@@ -38,12 +37,6 @@ try {
 	configuration.db = configuration.db[environment];
 	configuration.dfsHost = configuration.api[environment].dfsHost;
 	configuration.client = configuration.client[environment];
-
-	// Set DFS Proxy settings if defined in config
-	if (configuration.api[environment].hasOwnProperty(dfsProxyKey)) {
-		configuration.useDfsProxy = true;
-		configuration.dfsProxy = configuration.api[environment][dfsProxyKey];
-	}
 
 	mwConfiguration = yaml.safeLoad(
 		fs.readFileSync(mwSettings, charset)


### PR DESCRIPTION
[PLATFORM-1928](https://wikia-inc.atlassian.net/browse/PLATFORM-1928)

As we're removing the local Varnish instance, let's clean up the InteractiveMaps config.

The support for `dfsProxy` was removed in https://github.com/Wikia/interactive-maps/commit/9cfa9d6b0a2ad98fab5e9565fd1e144b6390f522#diff-f9e73866d0c327062cb1f2d5d0676cb4L27

See https://github.com/Wikia/config/pull/1634 for config cleanup

@nandy-andy / @RafLeszczynski / @artursitarski 