### PR TITLE
MAIN-6998: Proper name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,7 +50,7 @@ try {
 
 configuration.swift = mwConfiguration.wgFSSwiftDC[environment][env.WIKIA_DATACENTER];
 
-if (configuration.swift.servers.length === 0) {
+if (configuration.swift.server.length === 0) {
 	throw new Error('Invalid DFS servers list');
 }
 


### PR DESCRIPTION
It's `server` not `servers`

https://github.com/Wikia/config/blob/dev/CommonSettings.php#L3122

Original PR that breaks it: https://github.com/Wikia/config/pull/1665

/cc @macbre @RafalWilinski 
